### PR TITLE
Add PTv3 encoder option

### DIFF
--- a/config/generate/specs.json
+++ b/config/generate/specs.json
@@ -11,6 +11,9 @@
 
   "kld_weight" : 1e-5,
   "latent_std" : 0.25,
+
+  "encoder_type": "ptv3",
+  "encoder_kwargs": {"out_channels": 256},
   
   "sdf_lr" : 1e-4,
   "diff_lr" : 1e-5,

--- a/config/stage1/specs.json
+++ b/config/stage1/specs.json
@@ -15,7 +15,10 @@
     "log_freq" : 150,
     "kld_weight" : 1e-5,
     "latent_std" : 0.25,
-  
+
+    "encoder_type": "ptv3",
+    "encoder_kwargs": {"out_channels": 256},
+
     "sdf_lr" : 1e-4
 }
   

--- a/config/stage2/specs.json
+++ b/config/stage2/specs.json
@@ -8,6 +8,9 @@
 
   "diff_lr" : 1e-5,
 
+  "encoder_type": "ptv3",
+  "encoder_kwargs": {"out_channels": 256},
+
   "diffusion_specs" : {
     "timesteps" : 1000,
     "objective" : "pred_x0",

--- a/environment.yaml
+++ b/environment.yaml
@@ -73,6 +73,7 @@ dependencies:
   - zlib=1.2.12=h7f8727e_2
   - zstd=1.5.2=ha4553b6_0
   - pip:
+      - pointcept>=1.5
       - absl-py==1.1.0
       - addict==2.4.0
       - aiohttp==3.8.1

--- a/models/encoder_factory.py
+++ b/models/encoder_factory.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+from models.archs.encoders.conv_pointnet import ConvPointnet
+from models.archs.encoders.dgcnn import DGCNN
+from models.ptv3_encoder import PTv3Encoder
+
+ENCODER_REGISTRY: Dict[str, Any] = {
+    "conv_pointnet": ConvPointnet,
+    "dgcnn": DGCNN,
+    "ptv3": PTv3Encoder,
+}
+
+
+def get_encoder(name: str, **kwargs):
+    if name not in ENCODER_REGISTRY:
+        raise ValueError(f"Unknown encoder type: {name}")
+    cls = ENCODER_REGISTRY[name]
+    # filter kwargs unsupported by class
+    from inspect import signature
+    sig = signature(cls.__init__)
+    filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
+    return cls(**filtered)

--- a/models/gaussian_model.py
+++ b/models/gaussian_model.py
@@ -14,7 +14,7 @@ import math
 from einops import rearrange, reduce
 
 from models.archs.gs_decoder import * 
-from models.archs.encoders.conv_pointnet import ConvPointnet
+from models.encoder_factory import get_encoder
 from utils import evaluate
 
 
@@ -31,10 +31,19 @@ class GsModel(pl.LightningModule):
         self.tanh_act = model_specs.get("tanh_act", False)
         self.pn_hidden = model_specs.get("pn_hidden_dim", self.latent_dim)
 
-        if point2gs:
-            self.pointnet = ConvPointnet(c_dim=self.latent_dim, dim=3, hidden_dim=self.pn_hidden, plane_resolution=64)
-        else:    
-            self.pointnet = ConvPointnet(c_dim=self.latent_dim, dim=59, hidden_dim=self.pn_hidden, plane_resolution=64)
+        encoder_type = self.specs.get("encoder_type", "conv_pointnet")
+        encoder_kwargs = self.specs.get("encoder_kwargs", {})
+
+        in_dim = 3 if point2gs else 59
+        self.pointnet = get_encoder(
+            encoder_type,
+            c_dim=self.latent_dim,
+            dim=in_dim,
+            hidden_dim=self.pn_hidden,
+            plane_resolution=64,
+            out_channels=self.latent_dim,
+            **encoder_kwargs,
+        )
         
         self.model = GSDecoder(latent_size=self.latent_dim, hidden_dim=self.hidden_dim, skip_connection=self.skip_connection, tanh_act=self.tanh_act)
 

--- a/models/ptv3_encoder.py
+++ b/models/ptv3_encoder.py
@@ -1,0 +1,30 @@
+from typing import Tuple
+import torch
+import torch.nn as nn
+
+try:
+    from pointcept.models.backbones.ptv3 import PTV3Backbone  # type: ignore
+except Exception:
+    # allows docs generation or environments without pointcept
+    PTV3Backbone = None  # type: ignore
+
+class PTv3Encoder(nn.Module):
+    """Thin wrapper adapting Point Transformer V3 backbone to DiffGS."""
+
+    def __init__(self, out_channels: int = 256, **kwargs) -> None:
+        super().__init__()
+        if PTV3Backbone is None:
+            raise ImportError("pointcept is required for PTv3Encoder")
+        self.backbone = PTV3Backbone(width=out_channels)
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, None]:
+        """Forward pass.
+
+        Args:
+            x: Input tensor of shape [B, 3, N].
+        Returns:
+            Tuple of encoded features [B, C, N] and None for compatibility.
+        """
+        feats = self.backbone(x)  # [B, N, C]
+        feats = feats.permute(0, 2, 1).contiguous()  # -> [B, C, N]
+        return feats, None

--- a/tests/test_ptv3_encoder.py
+++ b/tests/test_ptv3_encoder.py
@@ -1,0 +1,6 @@
+from models.ptv3_encoder import PTv3Encoder
+import torch
+
+if __name__ == "__main__":
+    enc = PTv3Encoder()
+    print(enc(torch.randn(2, 3, 2048))[0].shape)


### PR DESCRIPTION
## Summary
- integrate Pointcept PTv3 backbone through new `PTv3Encoder`
- generic `encoder_factory` with registry
- allow choosing encoder via `encoder_type` and `encoder_kwargs`
- update configs with example PTv3 usage
- add pointcept>=1.5 to environment
- provide simple sanity script

## Testing
- `PYTHONPATH=. python tests/test_ptv3_encoder.py` *(fails: No module named 'torch')*