### PR TITLE
Add PTv3 encoder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ conda activate diffgs
 ```
 **Notice**：Since the code uses the original repository of Gaussian Splatting, please follow the environment setup instructions provided in the [official repository](https://github.com/graphdeco-inria/gaussian-splatting) to install the required dependencies.
 
+If you would like to experiment with the PTv3 encoder from [Pointcept](https://github.com/Pointcept/Pointcept), install the additional dependency via
+
+```
+pip install pointcept
+```
+and set `"encoder": "ptv3"` in `GSModelSpecs` of your configuration file. Training modes that rely on plane feature extraction are not supported when using PTv3.
+
 ## Pretrained model
 We first provide the pretrained models: `Gaussian VAE` and `Gaussian LDM` of the chair unconditional model. Please download the pretrained models from [Google Drive](https://drive.google.com/drive/folders/13JyZtXV6ep26HnVIiFza0jn9F8VL5I1_?usp=sharing).
 

--- a/config/generate/specs.json
+++ b/config/generate/specs.json
@@ -19,7 +19,8 @@
     "hidden_dim" : 512,
     "latent_dim" : 256,
     "pn_hidden_dim" : 128,
-    "num_layers" : 9
+    "num_layers" : 9,
+    "encoder" : "pointnet"
   },
 
   "diffusion_specs" : {

--- a/config/stage1/specs.json
+++ b/config/stage1/specs.json
@@ -8,7 +8,8 @@
       "hidden_dim" : 512,
       "latent_dim" : 256,
       "pn_hidden_dim" : 128,
-      "num_layers" : 9
+      "num_layers" : 9,
+      "encoder" : "pointnet"
     },
   
     "num_epochs" : 100001,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,6 +4,7 @@ from models.gaussian_model import GsModel
 from models.autoencoder import BetaVAE
 
 from models.archs.encoders.conv_pointnet import UNet
+from models.archs.encoders.ptv3 import PTv3Encoder
 
 from models.diffusion import *
 from models.archs.diffusion_arch import * 

--- a/models/archs/encoders/ptv3.py
+++ b/models/archs/encoders/ptv3.py
@@ -1,0 +1,67 @@
+"""PTv3 encoder wrapper."""
+
+import warnings
+import torch.nn as nn
+
+
+class PTv3Encoder(nn.Module):
+    """Wrapper for the PTv3 encoder from the Pointcept project.
+
+    This module requires the :mod:`pointcept` package. The constructor tries to
+    import the Point Transformer V3 implementation and will raise an informative
+    error if the package is missing. The interface is intentionally simple and
+    mirrors the minimal functionality used by :class:`GsModel`.
+    """
+
+    def __init__(self, c_dim=512, dim=3, **kwargs):
+        super().__init__()
+        try:
+            from pointcept.models.backbones.pt_v3 import PointTransformerV3
+        except Exception as exc:  # pragma: no cover - library might be missing
+            raise ImportError(
+                "PTv3Encoder requires the `pointcept` package. "
+                "Please install it from https://github.com/Pointcept/Pointcept"
+            ) from exc
+
+        self.model = PointTransformerV3(in_channels=dim, embed_dim=c_dim, **kwargs)
+
+    def forward(self, points, query=None):
+        """Forward pass of the encoder.
+
+        Parameters
+        ----------
+        points : Tensor
+            Input point cloud of shape ``(B, N, dim)``.
+        query : Tensor, optional
+            Query points. Currently ignored as PTv3 operates directly on the
+            input ``points``.
+        """
+        return self.model(points)
+
+    # The following methods are provided for API compatibility with
+    # :class:`ConvPointnet`. They fall back to using the query points
+    # directly and emit a warning so existing pipelines keep working.
+
+    def forward_with_plane_features(self, plane_features, query):  # noqa: D401
+        warnings.warn(
+            "PTv3Encoder ignores plane features; using query points directly",
+            stacklevel=2,
+        )
+        return self.forward(query)
+
+    def forward_with_pc_features(self, c, p, query):  # noqa: D401
+        warnings.warn(
+            "PTv3Encoder does not use precomputed point features; using query points",
+            stacklevel=2,
+        )
+        return self.forward(query)
+
+    def get_point_cloud_features(self, p):  # noqa: D401
+        """Return features for the input points."""
+        return self.model(p)
+
+    def get_plane_features(self, p):  # noqa: D401
+        """Plane features are unavailable for PTv3."""
+        raise NotImplementedError(
+            "PTv3Encoder does not provide plane features; consider using ConvPointnet"
+        )

--- a/models/combined_model.py
+++ b/models/combined_model.py
@@ -70,10 +70,15 @@ class CombinedModel(pl.LightningModule):
         gs = x['gaussians']
         gaussian_xyz = x['gaussian_xyz']
 
-        if self.point2gs:
-            plane_features = self.gs_model.pointnet.get_plane_features(gaussian_xyz)
-        else:
-            plane_features = self.gs_model.pointnet.get_plane_features(gs)
+        try:
+            if self.point2gs:
+                plane_features = self.gs_model.pointnet.get_plane_features(gaussian_xyz)
+            else:
+                plane_features = self.gs_model.pointnet.get_plane_features(gs)
+        except NotImplementedError as exc:
+            raise RuntimeError(
+                "The selected encoder does not provide plane features required for modulation training"
+            ) from exc
         original_features = torch.cat(plane_features, dim=1)
         out = self.vae_model(original_features)
         reconstructed_plane_feature, latent = out[0], out[-1]

--- a/models/gaussian_model.py
+++ b/models/gaussian_model.py
@@ -15,6 +15,7 @@ from einops import rearrange, reduce
 
 from models.archs.gs_decoder import * 
 from models.archs.encoders.conv_pointnet import ConvPointnet
+from models.archs.encoders.ptv3 import PTv3Encoder
 from utils import evaluate
 
 
@@ -30,11 +31,20 @@ class GsModel(pl.LightningModule):
         self.skip_connection = model_specs.get("skip_connection", True)
         self.tanh_act = model_specs.get("tanh_act", False)
         self.pn_hidden = model_specs.get("pn_hidden_dim", self.latent_dim)
+        encoder_type = model_specs.get("encoder", "pointnet").lower()
 
-        if point2gs:
-            self.pointnet = ConvPointnet(c_dim=self.latent_dim, dim=3, hidden_dim=self.pn_hidden, plane_resolution=64)
-        else:    
-            self.pointnet = ConvPointnet(c_dim=self.latent_dim, dim=59, hidden_dim=self.pn_hidden, plane_resolution=64)
+        dim_in = 3 if point2gs else 59
+        if encoder_type == "ptv3":
+            self.pointnet = PTv3Encoder(c_dim=self.latent_dim, dim=dim_in)
+        elif encoder_type in ("pointnet", "conv_pointnet"):
+            self.pointnet = ConvPointnet(
+                c_dim=self.latent_dim,
+                dim=dim_in,
+                hidden_dim=self.pn_hidden,
+                plane_resolution=64,
+            )
+        else:
+            raise ValueError(f"Unsupported encoder type: {encoder_type}")
         
         self.model = GSDecoder(latent_size=self.latent_dim, hidden_dim=self.hidden_dim, skip_connection=self.skip_connection, tanh_act=self.tanh_act)
 


### PR DESCRIPTION
## Summary
- allow selecting `ptv3` encoder through `GSModelSpecs` and add stub implementation
- document PTv3 dependency and configuration in README
- expose new encoder class in models package
- add `encoder` key to example config files

## Testing
- `python -m py_compile models/archs/encoders/ptv3.py models/gaussian_model.py models/__init__.py`
- `python -m json.tool config/stage1/specs.json`
- `python -m json.tool config/generate/specs.json`
- `pytest -q` *(fails: command not found)*