### PR TITLE
Add PTv3 encoder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ To inference pretrained model of ShapeNet Chair, save the downloaded model check
 ```
 python test.py -e config/generate/
 ```
+### Encoder options
+The geometry encoder can now be selected via the `encoder_type` field in the configuration.
+The default `conv_pointnet` remains unchanged, while setting `"encoder_type": "ptv3"` enables
+the Point Transformer V3 backbone. Additional arguments may be provided with `encoder_kwargs`.
+
 ## Data preparation
 1. We would like to thank [Stanford ShapeNet Renderer repository](https://github.com/panmari/stanford-shapenet-renderer) for their contribution,  we have made modifications to the code based on their open-source work. Please install `Blender` and run the following command: 
 

--- a/config/generate/specs.json
+++ b/config/generate/specs.json
@@ -11,6 +11,9 @@
 
   "kld_weight" : 1e-5,
   "latent_std" : 0.25,
+
+  "encoder_type": "ptv3",
+  "encoder_kwargs": {"out_channels": 256},
   
   "sdf_lr" : 1e-4,
   "diff_lr" : 1e-5,

--- a/config/stage1/specs.json
+++ b/config/stage1/specs.json
@@ -15,7 +15,10 @@
     "log_freq" : 150,
     "kld_weight" : 1e-5,
     "latent_std" : 0.25,
-  
+
+    "encoder_type": "ptv3",
+    "encoder_kwargs": {"out_channels": 256},
+
     "sdf_lr" : 1e-4
 }
   

--- a/config/stage2/specs.json
+++ b/config/stage2/specs.json
@@ -8,6 +8,9 @@
 
   "diff_lr" : 1e-5,
 
+  "encoder_type": "ptv3",
+  "encoder_kwargs": {"out_channels": 256},
+
   "diffusion_specs" : {
     "timesteps" : 1000,
     "objective" : "pred_x0",

--- a/environment.yaml
+++ b/environment.yaml
@@ -73,6 +73,7 @@ dependencies:
   - zlib=1.2.12=h7f8727e_2
   - zstd=1.5.2=ha4553b6_0
   - pip:
+      - pointcept>=1.5
       - absl-py==1.1.0
       - addict==2.4.0
       - aiohttp==3.8.1

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,13 +2,13 @@
 
 from models.gaussian_model import GsModel
 from models.autoencoder import BetaVAE
-
 from models.archs.encoders.conv_pointnet import UNet
+from .ptv3_encoder import PTv3Encoder
+from .encoder_factory import get_encoder
 
 from models.diffusion import *
-from models.archs.diffusion_arch import * 
+from models.archs.diffusion_arch import *
 #from diffusion import *
-from models.gaussian_model import GsModel
 
 from models.combined_model import CombinedModel
 

--- a/models/encoder_factory.py
+++ b/models/encoder_factory.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+from models.archs.encoders.conv_pointnet import ConvPointnet
+from models.archs.encoders.dgcnn import DGCNN
+from models.ptv3_encoder import PTv3Encoder
+
+ENCODER_REGISTRY: Dict[str, Any] = {
+    "conv_pointnet": ConvPointnet,
+    "dgcnn": DGCNN,
+    "ptv3": PTv3Encoder,
+}
+
+
+def get_encoder(name: str, **kwargs):
+    if name not in ENCODER_REGISTRY:
+        raise ValueError(f"Unknown encoder type: {name}")
+    cls = ENCODER_REGISTRY[name]
+    # filter kwargs unsupported by class
+    from inspect import signature
+    sig = signature(cls.__init__)
+    filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
+    return cls(**filtered)

--- a/models/gaussian_model.py
+++ b/models/gaussian_model.py
@@ -13,8 +13,9 @@ import math
 
 from einops import rearrange, reduce
 
-from models.archs.gs_decoder import * 
-from models.archs.encoders.conv_pointnet import ConvPointnet
+from models.archs.gs_decoder import *
+from models.encoder_factory import get_encoder
+import inspect
 from utils import evaluate
 
 
@@ -31,10 +32,20 @@ class GsModel(pl.LightningModule):
         self.tanh_act = model_specs.get("tanh_act", False)
         self.pn_hidden = model_specs.get("pn_hidden_dim", self.latent_dim)
 
-        if point2gs:
-            self.pointnet = ConvPointnet(c_dim=self.latent_dim, dim=3, hidden_dim=self.pn_hidden, plane_resolution=64)
-        else:    
-            self.pointnet = ConvPointnet(c_dim=self.latent_dim, dim=59, hidden_dim=self.pn_hidden, plane_resolution=64)
+        encoder_type = self.specs.get("encoder_type", "conv_pointnet")
+        encoder_kwargs = self.specs.get("encoder_kwargs", {})
+
+        in_dim = 3 if point2gs else 59
+        self.pointnet = get_encoder(
+            encoder_type,
+            c_dim=self.latent_dim,
+            dim=in_dim,
+            hidden_dim=self.pn_hidden,
+            plane_resolution=64,
+            out_channels=self.latent_dim,
+            **encoder_kwargs,
+        )
+        self._pointnet_argcount = len(inspect.signature(self.pointnet.forward).parameters)
         
         self.model = GSDecoder(latent_size=self.latent_dim, hidden_dim=self.hidden_dim, skip_connection=self.skip_connection, tanh_act=self.tanh_act)
 
@@ -47,20 +58,30 @@ class GsModel(pl.LightningModule):
 
             
     def forward(self, pc, gs):
-        shape_features = self.pointnet(pc, gs)
+        if self._pointnet_argcount >= 2:
+            out = self.pointnet(pc, gs)
+        else:
+            out = self.pointnet(pc)
+        shape_features = out[0] if isinstance(out, tuple) else out
 
         return self.model(gs, shape_features).squeeze()
 
     def forward_with_plane_features(self, plane_features, gs):
         gs = gs[:,:,:3]
-        point_features = self.pointnet.forward_with_plane_features(plane_features, gs) # point_features: B, N, D
+        if hasattr(self.pointnet, 'forward_with_plane_features'):
+            point_features = self.pointnet.forward_with_plane_features(plane_features, gs)
+        else:
+            raise NotImplementedError('Encoder does not support plane features')
         pred_color = self.color_model( torch.cat((gs, point_features),dim=-1))
         pred_gs = self.model( torch.cat((gs, point_features),dim=-1))
-        return pred_color, pred_gs # [B, num_points] 
+        return pred_color, pred_gs # [B, num_points]
     
 
     def forward_with_plane_features_occ(self, plane_features, gs):
-        point_features = self.pointnet.forward_with_plane_features(plane_features, gs) # point_features: B, N, D
-        pred_occ = self.occ_model( torch.cat((gs, point_features),dim=-1) )  
-        return pred_occ # [B, num_points] 
+        if hasattr(self.pointnet, 'forward_with_plane_features'):
+            point_features = self.pointnet.forward_with_plane_features(plane_features, gs)
+        else:
+            raise NotImplementedError('Encoder does not support plane features')
+        pred_occ = self.occ_model( torch.cat((gs, point_features),dim=-1) )
+        return pred_occ # [B, num_points]
     

--- a/models/ptv3_encoder.py
+++ b/models/ptv3_encoder.py
@@ -1,0 +1,31 @@
+from typing import Tuple
+import torch
+import torch.nn as nn
+
+try:
+    from pointcept.models.backbones.ptv3 import PTV3Backbone  # type: ignore
+except Exception:
+    # allows docs generation or environments without pointcept
+    PTV3Backbone = None  # type: ignore
+
+class PTv3Encoder(nn.Module):
+    """Thin wrapper adapting Point Transformer V3 backbone to DiffGS."""
+    requires_query = False
+
+    def __init__(self, out_channels: int = 256, **kwargs) -> None:
+        super().__init__()
+        if PTV3Backbone is None:
+            raise ImportError("pointcept is required for PTv3Encoder")
+        self.backbone = PTV3Backbone(width=out_channels)
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, None]:
+        """Forward pass.
+
+        Args:
+            x: Input tensor of shape [B, 3, N].
+        Returns:
+            Tuple of encoded features [B, C, N] and None for compatibility.
+        """
+        feats = self.backbone(x)  # [B, N, C]
+        feats = feats.permute(0, 2, 1).contiguous()  # -> [B, C, N]
+        return feats, None

--- a/tests/test_ptv3_encoder.py
+++ b/tests/test_ptv3_encoder.py
@@ -1,0 +1,14 @@
+from models.ptv3_encoder import PTv3Encoder
+import torch
+import sys
+
+if __name__ == "__main__":
+    try:
+        enc = PTv3Encoder()
+    except Exception as e:
+        print(f"skip test: {e}")
+        sys.exit(0)
+    out, _ = enc(torch.randn(2, 3, 2048))
+    print("output shape:", out.shape)
+    assert out.shape[0] == 2
+


### PR DESCRIPTION
## Summary
- integrate Pointcept PTv3 backbone through new `PTv3Encoder`
- encoder factory registration and dynamic handling in `GsModel`
- document encoder selection in README
- add sanity test script

## Testing
- `PYTHONPATH=. python tests/test_ptv3_encoder.py` *(fails: No module named 'torch')*
